### PR TITLE
feat: add claude_code_oauth_token to all GitHub workflow tests

### DIFF
--- a/.github/workflows/test-base-action.yml
+++ b/.github/workflows/test-base-action.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           prompt: ${{ github.event.inputs.test_prompt || 'List the files in the current directory starting with "package"' }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_tools: "LS,Read"
           timeout_minutes: "3"
 
@@ -82,6 +83,7 @@ jobs:
         with:
           prompt_file: "test-prompt.txt"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_tools: "LS,Read"
           timeout_minutes: "3"
 

--- a/.github/workflows/test-claude-env.yml
+++ b/.github/workflows/test-claude-env.yml
@@ -20,6 +20,7 @@ jobs:
           prompt: |
             Use the Bash tool to run: echo "VAR1: $VAR1" && echo "VAR2: $VAR2"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_env: |
             # This is a comment
             VAR1: value1

--- a/.github/workflows/test-mcp-servers.yml
+++ b/.github/workflows/test-mcp-servers.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           prompt: "List all available tools"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         env:
           # Change to test directory so it finds .mcp.json
           CLAUDE_WORKING_DIR: ${{ github.workspace }}/base-action/test/mcp-test
@@ -110,6 +111,7 @@ jobs:
         with:
           prompt: "List all available tools"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           mcp_config: '{"mcpServers":{"test-server":{"type":"stdio","command":"bun","args":["simple-mcp-server.ts"],"env":{}}}}'
         env:
           # Change to test directory so bun can find the MCP server script

--- a/.github/workflows/test-settings.yml
+++ b/.github/workflows/test-settings.yml
@@ -20,6 +20,7 @@ jobs:
           prompt: |
             Use Bash to echo "Hello from settings test"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           settings: |
             {
               "permissions": {
@@ -70,6 +71,7 @@ jobs:
           prompt: |
             Use Bash to echo "This should not work"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           settings: |
             {
               "permissions": {
@@ -113,6 +115,7 @@ jobs:
           prompt: |
             Use Bash to echo "Hello from settings file test"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           settings: "test-settings.json"
           timeout_minutes: "2"
 
@@ -168,6 +171,7 @@ jobs:
           prompt: |
             Use Bash to echo "This should not work from file"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           settings: "test-settings.json"
           timeout_minutes: "2"
 


### PR DESCRIPTION
Add claude_code_oauth_token parameter to all test workflow files to support new authentication method. This ensures proper authentication for Claude Code API access in GitHub Actions.

🤖 Generated with [Claude Code](https://claude.ai/code)